### PR TITLE
Fix COS mod detection and communications support variable

### DIFF
--- a/hdssystem/init-client.sqf
+++ b/hdssystem/init-client.sqf
@@ -7,17 +7,17 @@
         player setVariable ["ace_medical_medicClass",1,true];
         player setUnitTrait ["Medic",true];
         {_x synchronizeObjectsAdd [player]} foreach sontdesappuismedicals;
-    }
+      };
     } foreach sontdesmedecins;
     //---------------------------------------------------------------------
 
     //configuration des expert en transmission-----------------------------
     {
       if(vehiclevarname player isequalto _x)then{
-      [player,"Renfort_terrestre"] call bis_fnc_addcommMenuItem;
-      player setUnitTrait ["UAVHacker",true];
-      {_x synchronizeObjectsAdd [player]} foreach sontdesappuisexoertcoms;
-    }
+        [player,"Renfort_terrestre"] call bis_fnc_addcommMenuItem;
+        player setUnitTrait ["UAVHacker",true];
+        {_x synchronizeObjectsAdd [player]} foreach sontdesappuisexpertcoms;
+      };
     } foreach sontdesexpertcoms;
     //----------------------------------------------------------------------
 

--- a/mes-parametres.sqf
+++ b/mes-parametres.sqf
@@ -18,7 +18,7 @@ sontdespilotes = ["pilote_one","pilote_two","invite_5"];
 sontdescontractor = ["contractor_1","contractor_2","contractor_3","contractor_4","contractor_5","contractor_6"];
 
 sontdesappuismanageurs = [radio_appui];
-sontdesappuisexoertcoms = [radio_appui];
+sontdesappuisexpertcoms = [radio_appui];
 sontdesappuismedicals = [radio_appui];
 sontdesappuisingenieurs = [radio_appui];
 sontdesappuispilotes = [radio_appui];
@@ -35,7 +35,7 @@ if (isClass(configFile >> "CfgPatches" >> "po_main"))then{opforactive = true}els
 if (isClass(configFile >> "CfgPatches" >> "rhs_main"))then{afrfactive = true}else{afrfactive = false};              //rhsafrf
 if (isClass(configFile >> "CfgPatches" >> "rhsusf_main"))then{usafactive = true}else{usafactive = false};           //rhsusaf
 if (isClass(configFile >> "CfgPatches" >> "FFCamoPack_Common"))then{foxforactive = true}else{foxforactive = false}; //foxforCamoPack
-if (isClass(configFile >> "CfgPatches" >> "COS_equips"))then{cosactive = true}else{cosforactive = false};           //C.O.S
+cosactive = isClass (configFile >> "CfgPatches" >> "COS_equips");           //C.O.S
 if (isClass(configFile >> "CfgPatches" >> "rds_A2_Civilians"))then{rdsactive = true}else{rdsactive = false};        //RDS Civilian Pack
 if (isClass(configFile >> "CfgPatches" >> "Project_Numb_3"))then{numbactive = true}else{numbactive = false};        //Project_Numb_3 activé
 


### PR DESCRIPTION
## Summary
- ensure cosactive flag resets to false when COS_equips addon is missing
- fix typo in communications support variable name
- add missing semicolons in medic and comm expert blocks
- streamline COS addon detection with direct boolean assignment

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68af10bedd70832aa0b7a9befd58588d