### PR TITLE
Fix contractor typo in communication menu

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -102,7 +102,7 @@ class CfgCommunicationMenu
 {
 	class Renfort_terrestre
 	{
-		text = "call contrator | appeler des mercenaires";
+		text = "call contractor | appeler des mercenaires";
 		submenu = "";
 		expression = "[player] spawn fnc_renfort_allie;";
 		icon = "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa";


### PR DESCRIPTION
## Summary
- Correct typo in Renfort_terrestre menu item: "call contractor | appeler des mercenaires"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af15068344832a85b17da96b493ad9